### PR TITLE
Added DTOs for /order/create and example scenarios to _usage.py

### DIFF
--- a/_usage.py
+++ b/_usage.py
@@ -1,19 +1,131 @@
+import json
 import os
 
 from tapsilat_py.client import TapsilatAPI
-from tapsilat_py.models import BuyerDTO, OrderCreateDTO
+from tapsilat_py.exceptions import APIException
+from tapsilat_py.models import (
+    BasketItemDTO,
+    BasketItemPayerDTO,
+    BillingAddressDTO,
+    BuyerDTO,
+    CheckoutDesignDTO,
+    OrderCreateDTO,
+    ShippingAddressDTO,
+)
 
-API_KEY = str(os.getenv("TAPSILAT_API_KEY"))
+# TAPSILAT_API_KEY from environment
 
-buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
-order = OrderCreateDTO(amount=100, currency="TRY", locale="tr-TR", buyer=buyer)
+def get_api_client():
+    api_key = str(os.getenv("TAPSILAT_API_KEY"))
+    if not api_key:
+        print("Error: TAPSILAT_API_KEY is not set.")
+        return None
+    return TapsilatAPI(api_key=api_key)
 
-client = TapsilatAPI(API_KEY)
+def process_order_creation(client, order_payload, scenario_name):
+    print("#"*16)
+    print(f"{scenario_name}")
+    if not client:
+        return
 
-# Order create process
-order_response = client.create_order(order)
-print("Order create response: ", order_response)
+    try:
+        print("Request Payload:")
+        payload_dict = order_payload.to_dict() if hasattr(order_payload, 'to_dict') and callable(order_payload.to_dict) else {}
+        if not payload_dict:
+            from dataclasses import asdict
+            payload_dict = asdict(order_payload)
+        print(json.dumps(payload_dict, indent=2, ensure_ascii=False))
 
-# Get checkout url
-checkout_url = client.get_checkout_url(order_response)
-print("Checkout URL: ", checkout_url)
+        order_response = client.create_order(order_payload)
+        # print("\nCreate Order Response:", json.dumps(order_response, indent=2, ensure_ascii=False))
+
+        if order_response and order_response.get("reference_id"):
+            checkout_url = client.get_checkout_url(order_response)
+            print("\nCheckout URL:", checkout_url)
+            print("#"*16)
+            return order_response
+        else:
+            print("\nOrder creation failed or 'reference_id' not found in response.")
+            print("#"*16)
+            return None
+    except APIException as e:
+        print(f"\nAPI Error ({scenario_name}): Status: {e.status_code}, Code: {e.code}, Msg: {e.error}")
+        print("#"*16)
+        return None
+    except Exception as e:
+        print(f"\nUnexpected error ({scenario_name}): {e}")
+        import traceback
+        traceback.print_exc()
+        print("#"*16)
+        return None
+
+def run_scenario_1_basic_order(client):
+    buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    order_payload = OrderCreateDTO(amount=100.00, currency="TRY", locale="tr", buyer=buyer)
+    process_order_creation(client, order_payload, "Scenario 1: Basic Order")
+
+def run_scenario_2_order_with_basket_items(client):
+    buyer_data = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    basket_item1_payer = BasketItemPayerDTO(reference_id="payer_ref0_item1", type="PERSONAL")
+    basket_item1 = BasketItemDTO(id="B001", name="Item 1", price=10.00, quantity=1, item_type="PHYSICAL", payer=basket_item1_payer)
+    basket_item2_payer = BasketItemPayerDTO(reference_id="payer_ref1_item2", type="BUSINESS")
+    basket_item2 = BasketItemDTO(id="B002", name="Item 2", price=20.49, quantity=2, item_type="PHYSICAL", payer=basket_item2_payer)
+
+    order_payload = OrderCreateDTO(
+        amount=30.49,
+        currency="TRY",
+        locale="tr",
+        buyer=buyer_data,
+        basket_items=[basket_item1, basket_item2]
+    )
+    process_order_creation(client, order_payload, "Scenario 2: Order with Basket Items")
+
+def run_scenario_3_order_with_addresses(client):
+    buyer_data = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    billing_address_data = BillingAddressDTO(address="uskudar", city="Istanbul", country="TR", contact_name="John Doe", zip_code="34000")
+    shipping_address_data = ShippingAddressDTO(address="kadikoy", city="Istanbul", country="TR", contact_name="Jane Doe", zip_code="34001")
+
+    order_payload = OrderCreateDTO(
+        amount=25.00,
+        currency="TRY",
+        locale="tr",
+        buyer=buyer_data,
+        billing_address=billing_address_data,
+        shipping_address=shipping_address_data
+    )
+    process_order_creation(client, order_payload, "Scenario 3: Order with Billing and Shipping Addresses")
+
+def run_scenario_4_installments_and_payment_methods(client):
+    buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    payload = OrderCreateDTO(amount=1200.00, currency="TRY", locale="tr", buyer=buyer,
+        enabled_installments=[2, 3, 6, 9],
+        payment_methods=True,
+        payment_options=['credit_card','cash'],
+        payment_success_url="https://example.com/install_success_s8",
+        payment_failure_url="https://example.com/install_failure_s8")
+    process_order_creation(client, payload, "Scenario 4: Installments and Payment Methods")
+
+def run_scenario_5_detailed_checkout_design_full(client):
+    buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    design = CheckoutDesignDTO(
+        pay_button_color="#FF0000",
+        logo="http://example.com/logo.png",
+        input_background_color="#EEEEEE",
+        input_text_color="#333333",
+        right_background_color="#FAFAFA"
+    )
+    payload = OrderCreateDTO(amount=55.00, currency="TRY", locale="tr", buyer=buyer, checkout_design=design)
+    process_order_creation(client, payload, "Scenario 4: Detailed Checkout Design (Full)")
+
+
+if __name__ == "__main__":
+    api_client = get_api_client()
+    if api_client:
+        run_scenario_1_basic_order(api_client)
+        run_scenario_2_order_with_basket_items(api_client)
+        run_scenario_3_order_with_addresses(api_client)
+        run_scenario_4_installments_and_payment_methods(api_client)
+        run_scenario_5_detailed_checkout_design_full(api_client)
+        print("\nAll scenarios completed.")
+    else:
+        print("API client could not be initialized.")

--- a/tapsilat_py/models.py
+++ b/tapsilat_py/models.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, asdict
-from typing import Optional
+from dataclasses import asdict, dataclass
+from typing import List, Optional
 
 
 @dataclass
@@ -20,14 +20,161 @@ class BuyerDTO:
     title: Optional[str] = None
     zip_code: Optional[str] = None
 
+@dataclass
+class BasketItemPayerDTO:
+    address: Optional[str] = None
+    reference_id: Optional[str] = None
+    tax_office: Optional[str] = None
+    title: Optional[str] = None
+    type: Optional[str] = None
+    vat: Optional[str] = None
 
-# TODO : Add other models for order
+@dataclass
+class BasketItemDTO:
+    category1: Optional[str] = None
+    category2: Optional[str] = None
+    commission_amount: Optional[float] = None
+    coupon: Optional[str] = None
+    coupon_discount: Optional[float] = None
+    data: Optional[str] = None
+    id: Optional[str] = None
+    item_type: Optional[str] = None
+    name: Optional[str] = None
+    paid_amount: Optional[float] = None
+    payer: Optional[BasketItemPayerDTO] = None
+    price: Optional[float] = None
+    quantity: Optional[int] = None
+    quantity_float: Optional[float] = None
+    quantity_unit: Optional[str] = None
+    sub_merchant_key: Optional[str] = None
+    sub_merchant_price: Optional[str] = None
+
+@dataclass
+class BillingAddressDTO:
+    address: Optional[str] = None
+    billing_type: Optional[str] = None
+    citizenship: Optional[str] = None
+    city: Optional[str] = None
+    contact_name: Optional[str] = None
+    contact_phone: Optional[str] = None
+    country: Optional[str] = None
+    district: Optional[str] = None
+    tax_office: Optional[str] = None
+    title: Optional[str] = None
+    vat_number: Optional[str] = None
+    zip_code: Optional[str] = None
+
+@dataclass
+class CheckoutDesignDTO:
+    input_background_color: Optional[str] = None
+    input_text_color: Optional[str] = None
+    label_text_color: Optional[str] = None
+    left_background_color: Optional[str] = None
+    logo: Optional[str] = None
+    order_detail_html: Optional[str] = None
+    pay_button_color: Optional[str] = None
+    redirect_url: Optional[str] = None
+    right_background_color: Optional[str] = None
+    text_color: Optional[str] = None
+
+@dataclass
+class MetadataDTO:
+    key: str
+    value: str
+
+@dataclass
+class OrderCardDTO:
+    card_id: str
+    card_sequence: int
+
+@dataclass
+class PaymentTermDTO:
+    amount: Optional[float] = None
+    data: Optional[str] = None
+    due_date: Optional[str] = None
+    paid_date: Optional[str] = None
+    required: Optional[bool] = None
+    status: Optional[str] = None
+    term_reference_id: Optional[str] = None
+    term_sequence: Optional[int] = None
+
+@dataclass
+class OrderPFSubMerchantDTO:
+    address: Optional[str] = None
+    city: Optional[str] = None
+    country: Optional[str] = None
+    country_iso_code: Optional[str] = None
+    id: Optional[str] = None
+    mcc: Optional[str] = None
+    name: Optional[str] = None
+    org_id: Optional[str] = None
+    postal_code: Optional[str] = None
+    submerchant_nin: Optional[str] = None
+    submerchant_url: Optional[str] = None
+    terminal_no: Optional[str] = None
+
+@dataclass
+class ShippingAddressDTO:
+    address: Optional[str] = None
+    city: Optional[str] = None
+    contact_name: Optional[str] = None
+    country: Optional[str] = None
+    shipping_date: Optional[str] = None
+    tracking_code: Optional[str] = None
+    zip_code: Optional[str] = None
+
+@dataclass
+class SubOrganizationDTO:
+    acquirer: Optional[str] = None
+    address: Optional[str] = None
+    contact_first_name: Optional[str] = None
+    contact_last_name: Optional[str] = None
+    currency: Optional[str] = None
+    email: Optional[str] = None
+    gsm_number: Optional[str] = None
+    iban: Optional[str] = None
+    identity_number: Optional[str] = None
+    legal_company_title: Optional[str] = None
+    organization_name: Optional[str] = None
+    sub_merchant_external_id: Optional[str] = None
+    sub_merchant_key: Optional[str] = None
+    sub_merchant_type: Optional[str] = None
+    tax_number: Optional[str] = None
+    tax_office: Optional[str] = None
+
+@dataclass
+class SubmerchantDTO:
+    amount: Optional[float] = None
+    merchant_reference_id: Optional[str] = None
+    order_basket_item_id: Optional[str] = None
+
 @dataclass
 class OrderCreateDTO:
     amount: float
     currency: str
     locale: str
     buyer: BuyerDTO
+    basket_items: Optional[List[BasketItemDTO]] = None
+    billing_address: Optional[BillingAddressDTO] = None
+    checkout_design: Optional[CheckoutDesignDTO] = None
+    conversation_id: Optional[str] = None
+    enabled_installments: Optional[List[int]] = None
+    external_reference_id: Optional[str] = None
+    metadata: Optional[List[MetadataDTO]] = None
+    order_cards: Optional[OrderCardDTO] = None
+    paid_amount: Optional[float] = None
+    partial_payment: Optional[bool] = None
+    payment_failure_url: Optional[str] = None
+    payment_methods: Optional[bool] = None
+    payment_options: Optional[List[str]] = None
+    payment_success_url: Optional[str] = None
+    payment_terms: Optional[List[PaymentTermDTO]] = None
+    pf_sub_merchant: Optional[OrderPFSubMerchantDTO] = None
+    shipping_address: Optional[ShippingAddressDTO] = None
+    sub_organization: Optional[SubOrganizationDTO] = None
+    submerchants: Optional[List[SubmerchantDTO]] = None
+    tax_amount: Optional[float] = None
+    three_d_force: Optional[bool] = None
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/tests/order_test.py
+++ b/tests/order_test.py
@@ -1,22 +1,44 @@
 import json
+from dataclasses import asdict
 
 import pytest
 from requests.models import Response
 
 from tapsilat_py.client import TapsilatAPI
 from tapsilat_py.exceptions import APIException
-from tapsilat_py.models import BuyerDTO, OrderCreateDTO
+from tapsilat_py.models import (
+    BasketItemDTO,
+    BasketItemPayerDTO,
+    BillingAddressDTO,
+    BuyerDTO,
+    CheckoutDesignDTO,
+    MetadataDTO,
+    OrderCardDTO,
+    OrderCreateDTO,
+    OrderPFSubMerchantDTO,
+    PaymentTermDTO,
+    ShippingAddressDTO,
+    SubmerchantDTO,
+    SubOrganizationDTO,
+)
 
 
 class DummyResponse(Response):
     def __init__(self, json_data, status_code):
         super().__init__()
-        self._json = json_data
+        self._json_data = json_data
         self.status_code = status_code
-        self._content = json.dumps(json_data).encode()
 
-    def json(self):
-        return self._json
+        if isinstance(json_data, dict) or isinstance(json_data, list):
+            self._content = json.dumps(json_data).encode('utf-8')
+        elif isinstance(json_data, str):
+            self._content = json_data.encode('utf-8')
+        else:
+            self._content = b''
+        self.encoding = 'utf-8'
+
+    def json(self, **kwargs):
+        return self._json_data
 
 
 def test_order_to_dict():
@@ -24,7 +46,7 @@ def test_order_to_dict():
     order = OrderCreateDTO(
         amount=100,
         currency="TRY",
-        locale="tr-TR",
+        locale="tr",
         buyer=buyer,
     )
 
@@ -32,21 +54,34 @@ def test_order_to_dict():
 
     assert json_data["amount"] == 100
     assert json_data["currency"] == "TRY"
-    assert json_data["locale"] == "tr-TR"
+    assert json_data["locale"] == "tr"
     assert json_data["buyer"]["name"] == "John"
     assert json_data["buyer"]["surname"] == "Doe"
     assert json_data["buyer"]["email"] == "test@example.com"
 
+    assert json_data["basket_items"] is None
+    assert json_data.get("external_reference_id") is None
+    assert "external_reference_id" in json_data
+    assert json_data["external_reference_id"] is None
+
 
 def test_create_order_success(monkeypatch):
-    expected = {
+    expected_api_response = {
         "order_id": "mock-03d03353-78bc-4432-9da6-1433ecd7fbbb",
         "reference_id": "mock-03d03353-9b5b-4289-b231-ffbe50f8a79d",
     }
-    dummy = DummyResponse(expected, 200)
-    monkeypatch.setattr("requests.post", lambda *a, **k: dummy)
+    dummy = DummyResponse(expected_api_response, 200)
+
+    captured_payloads = []
+
+    def mock_post(url, json, headers, timeout):
+        captured_payloads.append(json)
+        return dummy
+
+    monkeypatch.setattr("requests.post", mock_post)
+
     buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
-    order = OrderCreateDTO(
+    order_payload = OrderCreateDTO(
         amount=100,
         currency="TRY",
         locale="tr",
@@ -54,42 +89,396 @@ def test_create_order_success(monkeypatch):
     )
     client = TapsilatAPI()
 
-    res = client.create_order(order)
+    api_response = client.create_order(order_payload)
 
-    assert res["order_id"] == "mock-03d03353-78bc-4432-9da6-1433ecd7fbbb"
-    assert res["reference_id"] == "mock-03d03353-9b5b-4289-b231-ffbe50f8a79d"
-    assert res == expected
+    assert api_response["order_id"] == "mock-03d03353-78bc-4432-9da6-1433ecd7fbbb"
+    assert api_response["reference_id"] == "mock-03d03353-9b5b-4289-b231-ffbe50f8a79d"
+    assert api_response == expected_api_response
 
+    assert len(captured_payloads) == 1
+    sent_payload = captured_payloads[0]
+    assert sent_payload["amount"] == 100
+    assert sent_payload["currency"] == "TRY"
+    assert sent_payload["locale"] == "tr"
+    assert sent_payload["buyer"]["name"] == "John"
+
+    assert sent_payload["basket_items"] is None
+    assert sent_payload.get("billing_address") is None
+
+def test_basket_item_payer_dto_asdict():
+    payer = BasketItemPayerDTO(address="uskudar", type="PERSONAL", reference_id="123456789")
+    payer_dict = asdict(payer)
+    assert payer_dict["address"] == "uskudar"
+    assert payer_dict["type"] == "PERSONAL"
+    assert payer_dict["reference_id"] == "123456789"
+    assert payer_dict["tax_office"] is None
+
+def test_basket_item_dto_asdict():
+    payer_data = BasketItemPayerDTO(address="uskudar", type="BTRINESS")
+    item = BasketItemDTO(
+        id="BI101",
+        name="Binocular",
+        price=19.99,
+        quantity=1,
+        item_type="PHYSICAL",
+        payer=payer_data
+    )
+    item_dict = asdict(item)
+    assert item_dict["id"] == "BI101"
+    assert item_dict["name"] == "Binocular"
+    assert item_dict["price"] == 19.99
+    assert item_dict["quantity"] == 1
+    assert item_dict["item_type"] == "PHYSICAL"
+    assert item_dict["payer"]["address"] == "uskudar"
+    assert item_dict["payer"]["type"] == "BTRINESS"
+    assert item_dict["category1"] is None
+
+def test_billing_address_dto_asdict():
+    billing = BillingAddressDTO(
+        address="uskudar",
+        city="Istanbul",
+        country="TR",
+        contact_name="Jane Doe"
+    )
+    billing_dict = asdict(billing)
+    assert billing_dict["address"] == "uskudar"
+    assert billing_dict["city"] == "Istanbul"
+    assert billing_dict["country"] == "TR"
+    assert billing_dict["contact_name"] == "Jane Doe"
+    assert billing_dict["zip_code"] is None
+
+def test_checkout_design_dto_asdict():
+    design = CheckoutDesignDTO(
+        pay_button_color="#FF0000",
+        logo="http://example.com/logo.png"
+    )
+    design_dict = asdict(design)
+    assert design_dict["pay_button_color"] == "#FF0000"
+    assert design_dict["logo"] == "http://example.com/logo.png"
+    assert design_dict["input_background_color"] is None
+
+def test_metadata_dto_asdict():
+    meta = MetadataDTO(key="key", value="value")
+    meta_dict = asdict(meta)
+    assert meta_dict["key"] == "key"
+    assert meta_dict["value"] == "value"
+
+def test_order_card_dto_asdict():
+    card = OrderCardDTO(card_id="123456789", card_sequence=1)
+    card_dict = asdict(card)
+    assert card_dict["card_id"] == "123456789"
+    assert card_dict["card_sequence"] == 1
+
+
+def test_payment_term_dto_asdict():
+    term = PaymentTermDTO(
+        amount=50.0,
+        due_date="2025-10-21T23:59:59Z",
+        status="PENDING",
+        term_sequence=1
+    )
+    term_dict = asdict(term)
+    assert term_dict["amount"] == 50.0
+    assert term_dict["due_date"] == "2025-10-21T23:59:59Z"
+    assert term_dict["status"] == "PENDING"
+    assert term_dict["term_sequence"] == 1
+    assert term_dict["data"] is None
+
+def test_order_pf_sub_merchant_dto_asdict():
+    pf_sub = OrderPFSubMerchantDTO(
+        id="123456789",
+        name="John Doe",
+        mcc="1234"
+    )
+    pf_sub_dict = asdict(pf_sub)
+    assert pf_sub_dict["id"] == "123456789"
+    assert pf_sub_dict["name"] == "John Doe"
+    assert pf_sub_dict["mcc"] == "1234"
+    assert pf_sub_dict["address"] is None
+
+def test_shipping_address_dto_asdict():
+    shipping = ShippingAddressDTO(
+        address="uskudar",
+        city="Istanbul",
+        country="Turkey",
+        contact_name="Jane Doe"
+    )
+    shipping_dict = asdict(shipping)
+    assert shipping_dict["address"] == "uskudar"
+    assert shipping_dict["city"] == "Istanbul"
+    assert shipping_dict["country"] == "Turkey"
+    assert shipping_dict["contact_name"] == "Jane Doe"
+    assert shipping_dict["zip_code"] is None
+
+def test_sub_organization_dto_asdict():
+    sub_org = SubOrganizationDTO(
+        organization_name="ACME Inc.",
+        sub_merchant_key="sub merchant key",
+        legal_company_title="ACME Inc."
+    )
+    sub_org_dict = asdict(sub_org)
+    assert sub_org_dict["organization_name"] == "ACME Inc."
+    assert sub_org_dict["sub_merchant_key"] == "sub merchant key"
+    assert sub_org_dict["legal_company_title"] == "ACME Inc."
+    assert sub_org_dict["acquirer"] is None
+
+def test_submerchant_dto_asdict():
+    submerchant = SubmerchantDTO(
+        amount=20.49,
+        merchant_reference_id="merchant reference id",
+        order_basket_item_id="BI101"
+    )
+    submerchant_dict = asdict(submerchant)
+    assert submerchant_dict["amount"] == 20.49
+    assert submerchant_dict["merchant_reference_id"] == "merchant reference id"
+    assert submerchant_dict["order_basket_item_id"] == "BI101"
+
+def test_create_order_with_basket_items(monkeypatch):
+    expected_api_response = {"order_id": "order_basket", "reference_id": "ref_basket"}
+    dummy = DummyResponse(expected_api_response, 200)
+
+    captured_payloads = []
+    def mock_post(url, json, headers, timeout):
+        captured_payloads.append(json)
+        return dummy
+    monkeypatch.setattr("requests.post", mock_post)
+
+    buyer_data = BuyerDTO(name="Test", surname="User")
+    basket_item1_payer = BasketItemPayerDTO(reference_id="payer_ref0_item1")
+    basket_item1 = BasketItemDTO(id="B001", name="Item 1", price=10.0, quantity=1, payer=basket_item1_payer)
+    basket_item2 = BasketItemDTO(id="B002", name="Item 2", price=20.49, quantity=2,
+                                 payer=BasketItemPayerDTO(reference_id="payer_ref1_item2"))
+
+    order_payload = OrderCreateDTO(
+        amount=50.0,
+        currency="TRD",
+        locale="en",
+        buyer=buyer_data,
+        basket_items=[basket_item1, basket_item2]
+    )
+    client = TapsilatAPI()
+    api_response = client.create_order(order_payload)
+
+    assert api_response == expected_api_response
+    assert len(captured_payloads) == 1
+    sent_payload = captured_payloads[0]
+
+    assert sent_payload["amount"] == 50.0
+    assert sent_payload["buyer"]["name"] == "Test"
+    assert len(sent_payload["basket_items"]) == 2
+    assert sent_payload["basket_items"][0]["id"] == "B001"
+    assert sent_payload["basket_items"][0]["price"] == 10.0
+    assert sent_payload["basket_items"][0]["payer"]["reference_id"] == "payer_ref0_item1"
+    assert sent_payload["basket_items"][1]["id"] == "B002"
+    assert sent_payload["basket_items"][1]["price"] == 20.49
+    assert sent_payload["basket_items"][1]["payer"]["reference_id"] == "payer_ref1_item2"
+
+
+def test_create_order_with_billing_and_shipping_address(monkeypatch):
+    expected_api_response = {"order_id": "order_addr", "reference_id": "ref_addr"}
+    dummy = DummyResponse(expected_api_response, 200)
+
+    captured_payloads = []
+    def mock_post(url, json, headers, timeout):
+        captured_payloads.append(json)
+        return dummy
+    monkeypatch.setattr("requests.post", mock_post)
+
+    buyer_data = BuyerDTO(name="Addr", surname="Test")
+    billing_address_data = BillingAddressDTO(address="uskudar", city="Istanbul", country="TR", contact_name="John Doe")
+    shipping_address_data = ShippingAddressDTO(address="uskudar", city="Istanbul", country="TR", contact_name="Jane Doe")
+
+    order_payload = OrderCreateDTO(
+        amount=25.0,
+        currency="EUR",
+        locale="de",
+        buyer=buyer_data,
+        billing_address=billing_address_data,
+        shipping_address=shipping_address_data
+    )
+    client = TapsilatAPI()
+    api_response = client.create_order(order_payload)
+
+    assert api_response == expected_api_response
+    assert len(captured_payloads) == 1
+    sent_payload = captured_payloads[0]
+
+    assert sent_payload["billing_address"]["address"] == "uskudar"
+    assert sent_payload["billing_address"]["city"] == "Istanbul"
+    assert sent_payload["billing_address"]["contact_name"] == "John Doe"
+    assert sent_payload["shipping_address"]["address"] == "uskudar"
+    assert sent_payload["shipping_address"]["city"] == "Istanbul"
+    assert sent_payload["shipping_address"]["contact_name"] == "Jane Doe"
+
+
+def test_create_order_with_metadata_and_order_card(monkeypatch):
+    expected_api_response = {"order_id": "order_meta_card", "reference_id": "ref_meta_card"}
+    dummy = DummyResponse(expected_api_response, 200)
+
+    captured_payloads = []
+    def mock_post(url, json, headers, timeout):
+        captured_payloads.append(json)
+        return dummy
+    monkeypatch.setattr("requests.post", mock_post)
+
+    buyer_data = BuyerDTO(name="John", surname="Doe")
+    metadata_list_data = [
+        MetadataDTO(key="source", value="mobile_app"),
+        MetadataDTO(key="campaign", value="summer_sale")
+    ]
+
+    order_card_data = OrderCardDTO(card_id="123456", card_sequence=1)
+
+    order_payload = OrderCreateDTO(
+        amount=99.0,
+        currency="TRY",
+        locale="tr",
+        buyer=buyer_data,
+        metadata=metadata_list_data,
+        order_cards=order_card_data
+    )
+    client = TapsilatAPI()
+    api_response = client.create_order(order_payload)
+
+    assert api_response == expected_api_response
+    assert len(captured_payloads) == 1
+    sent_payload = captured_payloads[0]
+
+    assert len(sent_payload["metadata"]) == 2
+    assert sent_payload["metadata"][0]["key"] == "source"
+    assert sent_payload["metadata"][1]["value"] == "summer_sale"
+    assert sent_payload["order_cards"]["card_id"] == "123456"
+    assert sent_payload["order_cards"]["card_sequence"] == 1
+
+
+def test_create_order_with_all_optional_fields_none(monkeypatch):
+    expected_api_response = {"order_id": "order_none", "reference_id": "ref_none"}
+    dummy = DummyResponse(expected_api_response, 200)
+
+    captured_payloads = []
+    def mock_post(url, json, headers, timeout):
+        captured_payloads.append(json)
+        return dummy
+    monkeypatch.setattr("requests.post", mock_post)
+
+    buyer_data = BuyerDTO(name="Jane", surname="Doe")
+    order_payload = OrderCreateDTO(
+        amount=10.0,
+        currency="TRY",
+        locale="tr",
+        buyer=buyer_data
+    )
+
+    client = TapsilatAPI()
+    api_response = client.create_order(order_payload)
+
+    assert api_response == expected_api_response
+    assert len(captured_payloads) == 1
+    sent_payload = captured_payloads[0]
+
+    assert sent_payload["amount"] == 10.0
+    assert sent_payload["buyer"]["name"] == "Jane"
+    assert sent_payload["basket_items"] is None
+    assert sent_payload["billing_address"] is None
+    assert sent_payload["checkout_design"] is None
+    assert sent_payload["conversation_id"] is None
+    assert sent_payload["enabled_installments"] is None
+    assert sent_payload["external_reference_id"] is None
+    assert sent_payload["metadata"] is None
+    assert sent_payload["order_cards"] is None
+    assert sent_payload["paid_amount"] is None
+    assert sent_payload["partial_payment"] is None
+    assert sent_payload["payment_failure_url"] is None
+    assert sent_payload["payment_methods"] is None
+    assert sent_payload["payment_options"] is None
+    assert sent_payload["payment_success_url"] is None
+    assert sent_payload["payment_terms"] is None
+    assert sent_payload["pf_sub_merchant"] is None
+    assert sent_payload["shipping_address"] is None
+    assert sent_payload["sub_organization"] is None
+    assert sent_payload["submerchants"] is None
+    assert sent_payload["tax_amount"] is None
+    assert sent_payload["three_d_force"] is None
+
+
+def test_create_order_with_payment_terms_and_submerchants(monkeypatch):
+    expected_api_response = {"order_id": "order_terms_sub", "reference_id": "ref_terms_sub"}
+    dummy = DummyResponse(expected_api_response, 200)
+
+    captured_payloads = []
+    def mock_post(url, json, headers, timeout):
+        captured_payloads.append(json)
+        return dummy
+    monkeypatch.setattr("requests.post", mock_post)
+
+    buyer_data = BuyerDTO(name="Jane", surname="Doe")
+    payment_terms_data = [
+        PaymentTermDTO(amount=50.0, due_date="2025-01-15", term_sequence=1, status="PENDING"),
+        PaymentTermDTO(amount=50.0, due_date="2025-02-15", term_sequence=2, status="PENDING")
+    ]
+    submerchants_list_data = [
+        SubmerchantDTO(amount=30.0, merchant_reference_id="sub1", order_basket_item_id="B001"),
+        SubmerchantDTO(amount=20.49, merchant_reference_id="sub2", order_basket_item_id="B002")
+    ]
+
+    order_payload = OrderCreateDTO(
+        amount=100.0,
+        currency="TRY",
+        locale="tr",
+        buyer=buyer_data,
+        payment_terms=payment_terms_data,
+        submerchants=submerchants_list_data,
+        checkout_design=CheckoutDesignDTO(logo="http://logo.url/img.png"),
+        pf_sub_merchant=OrderPFSubMerchantDTO(id="pfsm007", name="PF Sub"),
+        sub_organization=SubOrganizationDTO(organization_name="Sub Org")
+    )
+    client = TapsilatAPI()
+    api_response = client.create_order(order_payload)
+
+    assert api_response == expected_api_response
+    assert len(captured_payloads) == 1
+    sent_payload = captured_payloads[0]
+
+    assert len(sent_payload["payment_terms"]) == 2
+    assert sent_payload["payment_terms"][0]["amount"] == 50.0
+    assert sent_payload["payment_terms"][0]["term_sequence"] == 1
+    assert sent_payload["payment_terms"][1]["due_date"] == "2025-02-15"
+
+    assert len(sent_payload["submerchants"]) == 2
+    assert sent_payload["submerchants"][0]["merchant_reference_id"] == "sub1"
+    assert sent_payload["submerchants"][1]["amount"] == 20.49
+
+    assert sent_payload["checkout_design"]["logo"] == "http://logo.url/img.png"
+    assert sent_payload["pf_sub_merchant"]["id"] == "pfsm007"
+    assert sent_payload["sub_organization"]["organization_name"] == "Sub Org"
 
 def test_get_order_success(monkeypatch):
-    order_response = {"reference_id": "mock-03d03353-9b5b-4289-b231-ffbe50f8a79d"}
-    expected_response = {
-        "checkout_url": "https://checkout.tapsilat.dev?reference_id=mock-03d03353-d2be-4094-b5f6-7b7a8473534e"
+    order_response_arg = {"reference_id": "mock-03d03353-9b5b-4289-b231-ffbe50f8a79d"}
+    expected_api_response = {
+        "checkout_url": "https://checkout.test.dev?reference_id=mock-03d03353-d2be-4094-b5f6-7b7a8473534e",
+        "status": "PENDING"
     }
-    dummy = DummyResponse(expected_response, 200)
+    dummy = DummyResponse(expected_api_response, 200)
     monkeypatch.setattr("requests.get", lambda *a, **k: dummy)
 
     client = TapsilatAPI()
-    result = client.get_order(order_response)
+    result = client.get_order(order_response_arg)
 
     assert (
         result["checkout_url"]
-        == "https://checkout.tapsilat.dev?reference_id=mock-03d03353-d2be-4094-b5f6-7b7a8473534e"
+        == "https://checkout.test.dev?reference_id=mock-03d03353-d2be-4094-b5f6-7b7a8473534e"
     )
-    assert result == expected_response
+    assert result["status"] == "PENDING"
+    assert result == expected_api_response
 
 
 def test_get_order_reference_id_not_defined(monkeypatch):
-    order_response = {"error": "ORDER_ORDER_DETAIL_ORDER_NOT_FOUND"}
-    dummy = DummyResponse(
-        {"code": 101160, "error": "ORDER_ORDER_DETAIL_ORDER_NOT_FOUND"}, 400
-    )
-    monkeypatch.setattr("requests.get", lambda *a, **k: dummy)
+    order_response_arg_missing_ref_id = {"error": "some_previous_error", "order_id": "mock-03d03343-d2be-4094-b5f6-7b7a8473534e"}
 
     client = TapsilatAPI()
 
     with pytest.raises(APIException) as e:
-        client.get_order(order_response)
+        client.get_order(order_response_arg_missing_ref_id)
 
     assert e.value.status_code == 0
     assert e.value.code == 0
@@ -97,19 +486,18 @@ def test_get_order_reference_id_not_defined(monkeypatch):
 
 
 def test_get_order_failure(monkeypatch):
-    order_response = {
-        "order_id": "mock-03d03353-78bc-4432-9da6-1433ecd7fbbb",
-        "reference_id": "mock-03d03353-9b5b-4289-b231-ffbe50f8a79d",
+    order_response_arg = {
+        "reference_id": "mock-failed-reference-id",
     }
-    dummy = DummyResponse(
-        {"code": 101160, "error": "ORDER_ORDER_DETAIL_ORDER_NOT_FOUND"}, 400
-    )
+
+    api_error_response = {"code": 101160, "error": "ORDER_ORDER_DETAIL_ORDER_NOT_FOUND"}
+    dummy = DummyResponse(api_error_response, 400)
     monkeypatch.setattr("requests.get", lambda *a, **k: dummy)
 
     client = TapsilatAPI()
 
     with pytest.raises(APIException) as e:
-        client.get_order(order_response)
+        client.get_order(order_response_arg)
 
     assert e.value.status_code == 400
     assert e.value.code == 101160
@@ -117,17 +505,30 @@ def test_get_order_failure(monkeypatch):
 
 
 def test_get_checkout_url_success(monkeypatch):
-    order_response = {"reference_id": "mock-03d03353-9b5b-4289-b231-ffbe50f8a79d"}
-    expected_response = {
-        "checkout_url": "https://checkout.tapsilat.dev?reference_id=mock-03d03353-d2be-4094-b5f6-7b7a8473534e"
+    order_response_arg = {"reference_id": "mock-ref-for-checkout"}
+    get_order_api_response = {
+        "checkout_url": "https://checkout.test.dev?reference_id=mock-checkout-url-generated",
+        "status": "Waiting for payment"
     }
-    dummy = DummyResponse(expected_response, 200)
+    dummy = DummyResponse(get_order_api_response, 200)
+
     monkeypatch.setattr("requests.get", lambda *a, **k: dummy)
 
     client = TapsilatAPI()
-    url = client.get_checkout_url(order_response)
+    checkout_url_result = client.get_checkout_url(order_response_arg)
 
     assert (
-        url
-        == "https://checkout.tapsilat.dev?reference_id=mock-03d03353-d2be-4094-b5f6-7b7a8473534e"
+        checkout_url_result
+        == "https://checkout.test.dev?reference_id=mock-checkout-url-generated"
     )
+
+def test_get_checkout_url_raises_exception_if_reference_id_missing_in_arg(monkeypatch):
+    order_response_arg_missing_ref_id = {"order_id": "order123_no_ref"}
+    client = TapsilatAPI()
+
+    with pytest.raises(APIException) as e:
+        client.get_checkout_url(order_response_arg_missing_ref_id)
+
+    assert e.value.status_code == 0
+    assert e.value.code == 0
+    assert e.value.error == "reference_id is not defined!"


### PR DESCRIPTION
* Added all necessary DTOs for the /order/create endpoint
* Included a few example scenarios in _usage.py for testing and documentation