### PR TITLE
Order cancel method

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ TAPSILAT_API_KEY=your_api_key_here
 ## Usage
 ```python
 import os
+
 from tapsilat_py.client import TapsilatAPI
-from tapsilat_py.models import OrderCreateDTO, BuyerDTO
+from tapsilat_py.models import BuyerDTO, OrderCreateDTO
 
 API_KEY = str(os.getenv("TAPSILAT_API_KEY"))
 
@@ -37,7 +38,15 @@ client = TapsilatAPI(API_KEY)
 order_response = client.create_order(order)
 print("Order create response: ", order_response)
 
+# Get reference id from response
+reference_id = order_response.reference_id
+
 # Get checkout url
-checkout_url = client.get_checkout_url(order_response)
+checkout_url = client.get_checkout_url(reference_id)
 print("Checkout URL: ", checkout_url)
+
+# Order cancel process
+cancel_order_response = client.cancel_order(reference_id)
+print("Order cancel response:",cancel_order_response)
 ```
+

--- a/tapsilat_py/models.py
+++ b/tapsilat_py/models.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass
-from typing import List, Optional
+from typing import Any, List, Optional
 
 
 @dataclass
@@ -178,3 +178,18 @@ class OrderCreateDTO:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+@dataclass
+class CancelOrderDTO:
+    reference_id: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+class OrderResponse(dict):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+    @property
+    def reference_id(self) -> str:
+        return self.get("reference_id")


### PR DESCRIPTION
* cancel_order method and usage added to README.
* get_order and get_checkout_url methods have also been updated to operate using reference_id, like cancel_order.