### PR TITLE
pypi.yaml builder python-version update

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.6'
+        python-version: '3.x'
     - name: Install build and publish dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Update builder python version from 3.6 to 3.x to enable automatic version selection.

Current configuration fails with following error:
```
Version 3.6 was not found in the local cache
  Error: The version '3.6' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
 ```