### PR TITLE
Validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,56 @@ API_KEY = str(os.getenv("TAPSILAT_API_KEY"))
 client = TapsilatAPI(API_KEY)
 ```
 
+### Validators
+The SDK includes built-in validators for common data types:
+
+#### GSM Number Validation
+```python
+from tapsilat_py.validators import validate_gsm_number
+
+# Valid formats
+valid_gsm = validate_gsm_number("+905551234567")  # International with +
+valid_gsm = validate_gsm_number("00905551234567")  # International with 00
+valid_gsm = validate_gsm_number("05551234567")     # National format
+valid_gsm = validate_gsm_number("5551234567")      # Local format
+
+# Automatically cleans formatting
+clean_gsm = validate_gsm_number("+90 555 123-45-67")  # Returns: "+905551234567"
+
+# Raises APIException for invalid formats
+try:
+    validate_gsm_number("invalid-phone")
+except APIException as e:
+    print(f"Error: {e.error}")
+```
+
+#### Installments Validation
+```python
+from tapsilat_py.validators import validate_installments
+
+# Valid installment strings
+installments = validate_installments("1,2,3,6")     # Returns: [1, 2, 3, 6]
+installments = validate_installments("1, 2, 3, 6") # Handles spaces
+installments = validate_installments("")            # Returns: [1] (default)
+
+# Raises APIException for invalid values
+try:
+    validate_installments("1,15,abc")  # 15 > 12, abc is not a number
+except APIException as e:
+    print(f"Error: {e.error}")
+```
+
 ### Order create process
 ```python
 from tapsilat_py.models import BuyerDTO, OrderCreateDTO
-buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+
+# GSM number will be automatically validated in create_order
+buyer = BuyerDTO(
+    name="John", 
+    surname="Doe", 
+    email="test@example.com",
+    gsm_number="+90 555 123-45-67"  # Will be cleaned automatically
+)
 order = OrderCreateDTO(amount=100, currency="TRY", locale="tr", buyer=buyer)
 
 order_response = client.create_order(order)

--- a/_usage.py
+++ b/_usage.py
@@ -12,6 +12,7 @@ from tapsilat_py.models import (
     OrderCreateDTO,
     ShippingAddressDTO,
 )
+from tapsilat_py.validators import validate_gsm_number, validate_installments
 
 # TAPSILAT_API_KEY from environment
 
@@ -117,6 +118,46 @@ def run_scenario_5_detailed_checkout_design_full(client):
     payload = OrderCreateDTO(amount=55.00, currency="TRY", locale="tr", buyer=buyer, checkout_design=design)
     process_order_creation(client, payload, "Scenario 4: Detailed Checkout Design (Full)")
 
+def run_scenario_6_validation_demo(client):
+    try:
+        # Test GSM validation
+        valid_gsm = validate_gsm_number("+905551234567")
+        print(f"Valid GSM: {valid_gsm}")
+
+        # Test installments validation
+        valid_installments = validate_installments("1,2,3,6")
+        print(f"Valid installments: {valid_installments}")
+
+        # Create order with validated data
+        buyer = BuyerDTO(
+            name="John",
+            surname="Doe",
+            email="test@example.com",
+            gsm_number="+905551234567"
+        )
+        order_payload = OrderCreateDTO(
+            amount=100.00,
+            currency="TRY",
+            locale="tr",
+            buyer=buyer,
+            enabled_installments=[1, 2, 3, 6]
+        )
+        process_order_creation(client, order_payload, "Scenario 6: Validation Demo")
+
+    except APIException as e:
+        print(f"Validation Error: {e.error}")
+
+def run_scenario_7_validation_errors(client):
+    try:
+        validate_gsm_number("invalid-phone")
+    except APIException as e:
+        print(f"GSM Validation Error: {e.error}")
+
+    try:
+        validate_installments("1,15,abc")
+    except APIException as e:
+        print(f"Installments Validation Error: {e.error}")
+
 
 if __name__ == "__main__":
     api_client = get_api_client()
@@ -126,6 +167,8 @@ if __name__ == "__main__":
         run_scenario_3_order_with_addresses(api_client)
         run_scenario_4_installments_and_payment_methods(api_client)
         run_scenario_5_detailed_checkout_design_full(api_client)
+        run_scenario_6_validation_demo(api_client)
+        run_scenario_7_validation_errors(api_client)
         print("\nAll scenarios completed.")
     else:
         print("API client could not be initialized.")

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (here / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="tapsilat-py",
-    version="2025.06.11.1",
+    version="2025.06.24.1",
     description="Client SDK for Tapsilat API",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tapsilat_py/__init__.py
+++ b/tapsilat_py/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2025.06.11.1"
+__version__ = "2025.06.24.1"
 
 from .client import TapsilatAPI
 from .exceptions import APIException

--- a/tapsilat_py/client.py
+++ b/tapsilat_py/client.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional
 
 import requests
-from dotenv import load_dotenv
 
 from .exceptions import APIException
 from .models import (
@@ -13,8 +12,6 @@ from .models import (
     RefundOrderDTO,
 )
 from .validators import validate_gsm_number, validate_installments
-
-load_dotenv()
 
 
 class TapsilatAPI:

--- a/tapsilat_py/validators.py
+++ b/tapsilat_py/validators.py
@@ -1,0 +1,77 @@
+from typing import List
+
+from .exceptions import APIException
+
+
+def validate_installments(installments_str: str) -> List[int]:
+    """
+    Validate and parse installments string. Returns list of valid installment string
+    """
+    if not installments_str:
+        return [1]
+    try:
+        installments = [int(x.strip()) for x in installments_str.split(',')]
+        for installment in installments:
+            if installment < 1 or installment > 12:
+                raise APIException(
+                    status_code=400,
+                    code=0,
+                    error=f"Installment value '{installment}' is invalid. All installment values must be between 1 and 12 (inclusive)."
+                )
+        return installments if installments else [1]
+    except ValueError:
+        raise APIException(
+            status_code=400,
+            code=0,
+            error="Enabled installments must be comma-separated integers (e.g., 1,2,3 or 2,4,6)"
+        )
+    except AttributeError:
+        return [1]
+
+
+def validate_gsm_number(phone: str) -> str:
+    """
+    Validate GSM number format. Returns the original phone if valid.
+    """
+    if not phone:
+        return phone
+
+    clean_phone = phone.replace(' ', '').replace('-', '').replace('(', '').replace(')', '')
+
+    if not clean_phone.replace('+', '').replace('0', '').isdigit():
+        raise APIException(
+            status_code=400,
+            code=0,
+            error=f"Invalid phone number format: {phone}"
+        )
+
+    if clean_phone.startswith('+'):
+        if len(clean_phone) < 8:
+            raise APIException(
+                status_code=400,
+                code=0,
+                error=f"International phone number too short: {phone}"
+            )
+    elif clean_phone.startswith('00'):
+        if len(clean_phone) < 9:
+            raise APIException(
+                status_code=400,
+                code=0,
+                error=f"International phone number (00 format) too short: {phone}"
+            )
+    elif clean_phone.startswith('0'):
+        if len(clean_phone) < 7:
+            raise APIException(
+                status_code=400,
+                code=0,
+                error=f"National phone number too short: {phone}"
+            )
+    else:
+        if len(clean_phone) < 6:
+            raise APIException(
+                status_code=400,
+                code=0,
+                error=f"Local phone number too short: {phone}"
+            )
+
+    return clean_phone

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,111 @@
+import pytest
+
+from tapsilat_py.exceptions import APIException
+from tapsilat_py.validators import validate_gsm_number, validate_installments
+
+
+class TestValidateInstallments:
+    def test_empty_string_returns_default(self):
+        result = validate_installments("")
+        assert result == [1]
+
+    def test_none_returns_default(self):
+        result = validate_installments(None) # type: ignore
+        assert result == [1]
+
+    def test_valid_single_installment(self):
+        result = validate_installments("3")
+        assert result == [3]
+
+    def test_valid_multiple_installments(self):
+        result = validate_installments("1,2,3,6")
+        assert result == [1, 2, 3, 6]
+
+    def test_valid_with_spaces(self):
+        result = validate_installments("1, 2, 3, 6")
+        assert result == [1, 2, 3, 6]
+
+    def test_installment_value_too_low(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_installments("0,2,3")
+        assert exc_info.value.code == 0
+
+    def test_installment_value_too_high(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_installments("1,15,3")
+        assert exc_info.value.code == 0
+
+    def test_invalid_format_letters(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_installments("1,abc,3")
+        assert exc_info.value.code == 0
+
+    def test_invalid_format_mixed(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_installments("1,2.5,3")
+        assert exc_info.value.code == 0
+
+
+class TestValidateGsmNumber:
+    def test_empty_string_returns_empty(self):
+        result = validate_gsm_number("")
+        assert result == ""
+
+    def test_none_returns_none(self):
+        result = validate_gsm_number(None) # type: ignore
+        assert result is None
+
+    def test_valid_international_plus_format(self):
+        result = validate_gsm_number("+905551234567")
+        assert result == "+905551234567"
+
+    def test_valid_international_00_format(self):
+        result = validate_gsm_number("00905551234567")
+        assert result == "00905551234567"
+
+    def test_valid_national_format(self):
+        result = validate_gsm_number("05551234567")
+        assert result == "05551234567"
+
+    def test_valid_local_format(self):
+        result = validate_gsm_number("5551234567")
+        assert result == "5551234567"
+
+    def test_removes_formatting_characters(self):
+        result = validate_gsm_number("+90 555 123-45(67)")
+        assert result == "+905551234567"
+
+    def test_international_plus_too_short(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_gsm_number("+90123")
+        assert exc_info.value.code == 0
+        assert "too short" in exc_info.value.error
+
+    def test_international_00_too_short(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_gsm_number("0090123")
+        assert exc_info.value.code == 0
+        assert "too short" in exc_info.value.error
+
+    def test_national_too_short(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_gsm_number("012345")
+        assert exc_info.value.code == 0
+        assert "too short" in exc_info.value.error
+
+    def test_local_too_short(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_gsm_number("12345")
+        assert exc_info.value.code == 0
+        assert "too short" in exc_info.value.error
+
+    def test_invalid_characters(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_gsm_number("+90abc1234567")
+        assert exc_info.value.code == 0
+        assert "Invalid phone number format" in exc_info.value.error
+
+    def test_only_special_characters(self):
+        with pytest.raises(APIException) as exc_info:
+            validate_gsm_number("+++---")
+        assert exc_info.value.code == 0


### PR DESCRIPTION
### Changes
- Added `validators.py` with gsm number and installments validation
- `create_order()` now automatically validates and cleans gsm numbers
- Updated tests 
- Removed unused dotenv import

### Testing
```bash
pytest tests/test_validators.py -v
python _usage.py