### PR TITLE
feat(workflow): add SDK parity dispatch workflow

### DIFF
--- a/.github/workflows/sdk-parity-dispatch.yml
+++ b/.github/workflows/sdk-parity-dispatch.yml
@@ -1,0 +1,19 @@
+name: SDK Parity Dispatch
+
+on:
+  push:
+    paths:
+      - "tapsilat_py/**"
+      - "pyproject.toml"
+      - "setup.py"
+  pull_request:
+    paths:
+      - "tapsilat_py/**"
+      - "pyproject.toml"
+      - "setup.py"
+  workflow_dispatch:
+
+jobs:
+  parity-dispatch:
+    uses: tapsilat/tapsilat-sdk-parity/.github/workflows/reusable-sdk-parity-dispatch.yml@main
+    secrets: inherit


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for SDK parity dispatch.
- Triggers on push and pull request events for specific paths.
- Utilizes a reusable workflow from the tapsilat repository.