### PR TITLE
feat: add new order endpoints and models

### DIFF
--- a/tapsilat_py/__init__.py
+++ b/tapsilat_py/__init__.py
@@ -4,6 +4,8 @@ from .client import TapsilatAPI
 from .exceptions import APIException
 from .models import (
     OrderCreateDTO,
+    OrderPaymentOptionsUpdateDTO,
+    SplitOrderItemPaymentDTO,
     SubscriptionBilling,
     SubscriptionCancelRequest,
     SubscriptionCreateRequest,
@@ -16,6 +18,8 @@ __all__ = [
     "TapsilatAPI",
     "APIException",
     "OrderCreateDTO",
+    "OrderPaymentOptionsUpdateDTO",
+    "SplitOrderItemPaymentDTO",
     "SubscriptionBilling",
     "SubscriptionCancelRequest",
     "SubscriptionCreateRequest",

--- a/tapsilat_py/client.py
+++ b/tapsilat_py/client.py
@@ -36,6 +36,8 @@ from .models import (
     RemoveBasketItemRequest,
     UpdateBasketItemRequest,
     CallbackURLDTO,
+    OrderPaymentOptionsUpdateDTO,
+    SplitOrderItemPaymentDTO,
 )
 from .validators import validate_gsm_number, validate_installments
 
@@ -250,6 +252,24 @@ class TapsilatAPI:
         endpoint = "/order/releated"
         payload = request.to_dict()
         return self._make_request("PATCH", endpoint, json_payload=payload)
+
+    def update_payment_options(self, request: OrderPaymentOptionsUpdateDTO) -> dict:
+        endpoint = "/order/payment-options"
+        payload = request.to_dict()
+        return self._make_request("PATCH", endpoint, json_payload=payload)
+
+    def split_order_item_payment(self, request: SplitOrderItemPaymentDTO) -> dict:
+        endpoint = "/order/split"
+        payload = request.to_dict()
+        return self._make_request("POST", endpoint, json_payload=payload)
+
+    def order_callback(self, id: str) -> dict:
+        endpoint = f"/orders/{id}/callback"
+        return self._make_request("GET", endpoint)
+
+    def order_vpos_query(self, id: str) -> dict:
+        endpoint = f"/orders/{id}/vpos-query"
+        return self._make_request("GET", endpoint)
 
     def add_basket_item(self, request: AddBasketItemRequest) -> dict:
         endpoint = "/order/basket-item"

--- a/tapsilat_py/models.py
+++ b/tapsilat_py/models.py
@@ -572,3 +572,22 @@ class OrgUserMobileVerifyReq:
 
     def to_dict(self) -> dict:
         return _asdict_factory(self)
+
+
+@dataclass
+class OrderPaymentOptionsUpdateDTO:
+    payment_options: List[str]
+    reference_id: str
+
+    def to_dict(self) -> dict:
+        return _asdict_factory(self)
+
+
+@dataclass
+class SplitOrderItemPaymentDTO:
+    amount: float
+    order_id: str
+    order_item_payment_id: str
+
+    def to_dict(self) -> dict:
+        return _asdict_factory(self)

--- a/tests/integration/integration_test.py
+++ b/tests/integration/integration_test.py
@@ -21,6 +21,8 @@ from tapsilat_py.models import (
     OrderPostAuthRequest,
     OrderPaymentDetailDTO,
     CancelOrderDTO,
+    OrderPaymentOptionsUpdateDTO,
+    SplitOrderItemPaymentDTO,
 )
 from tapsilat_py.validators import validate_gsm_number, validate_installments
 
@@ -242,12 +244,9 @@ def test_scenario_10_subscription_lifecycle(api_client):
     assert isinstance(cancel_response, dict)
 
 
-def test_scenario_11_order_operations_smoke(api_client):
+def test_scenario_11_order_management_operations(api_client):
     """
-    A smoke test to ensure that the un-tested getter and setter endpoints in client.py
-    are structurally sound and do not raise unexpected local exceptions before HTTP.
-    Note: Real success depends on actual reference IDs which we don't always have,
-    so we might catch APIExceptions but their structure should be valid.
+    General test for order-related getter and setter endpoints.
     """
     # get_system_order_statuses
     try:
@@ -299,12 +298,6 @@ def test_scenario_11_order_operations_smoke(api_client):
     except APIException:
         pass
 
-    # cancel_order
-    try:
-        api_client.cancel_order(CancelOrderDTO(reference_id=dummy_ref))
-    except APIException:
-        pass
-
     # get_order_payment_details
     try:
         api_client.get_order_payment_details(
@@ -316,5 +309,64 @@ def test_scenario_11_order_operations_smoke(api_client):
     # get_order_payment_details_by_id
     try:
         api_client.get_order_payment_details_by_id(dummy_ref)
+    except APIException:
+        pass
+
+    # cancel_order
+    try:
+        api_client.cancel_order(CancelOrderDTO(reference_id=dummy_ref))
+    except APIException:
+        pass
+
+
+def test_scenario_12_update_payment_options(api_client):
+    buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    order = api_client.create_order(
+        OrderCreateDTO(amount=100.0, currency="TRY", locale="tr", buyer=buyer)
+    )
+    ref_id = order.reference_id
+
+    try:
+        api_client.update_payment_options(
+            OrderPaymentOptionsUpdateDTO(
+                reference_id=ref_id, payment_options=["credit_card"]
+            )
+        )
+    except APIException:
+        pass
+
+
+def test_scenario_13_split_order_item_payment(api_client):
+    buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    order = api_client.create_order(
+        OrderCreateDTO(amount=100.0, currency="TRY", locale="tr", buyer=buyer)
+    )
+    ref_id = order.reference_id
+
+    try:
+        # Note: In a real scenario, you'd need a valid order_item_payment_id
+        api_client.split_order_item_payment(
+            SplitOrderItemPaymentDTO(
+                order_id=ref_id, order_item_payment_id=ref_id, amount=1.0
+            )
+        )
+    except APIException:
+        pass
+
+
+def test_scenario_14_order_callback_and_vpos_query(api_client):
+    buyer = BuyerDTO(name="John", surname="Doe", email="test@example.com")
+    order = api_client.create_order(
+        OrderCreateDTO(amount=100.0, currency="TRY", locale="tr", buyer=buyer)
+    )
+    ref_id = order.reference_id
+
+    try:
+        api_client.order_callback(ref_id)
+    except APIException:
+        pass
+
+    try:
+        api_client.order_vpos_query(ref_id)
     except APIException:
         pass

--- a/tests/unit/test_order.py
+++ b/tests/unit/test_order.py
@@ -26,6 +26,8 @@ from tapsilat_py.models import (
     TerminateRequest,
     OrderManualCallbackDTO,
     OrderRelatedReferenceDTO,
+    OrderPaymentOptionsUpdateDTO,
+    SplitOrderItemPaymentDTO,
 )
 
 
@@ -881,3 +883,53 @@ def test_create_order_with_invalid_gsm_raises_exception(mock_api_request):
 
     assert exc_info.value.code == 0
     mock_api_request.assert_not_called()
+
+
+def test_update_payment_options(mock_api_request):
+    mock_api_request.return_value = {"status": "success"}
+
+    req = OrderPaymentOptionsUpdateDTO(
+        reference_id="ref123", payment_options=["credit_card", "cash"]
+    )
+    client = TapsilatAPI()
+    response = client.update_payment_options(req)
+
+    mock_api_request.assert_called_once_with(
+        "PATCH", "/order/payment-options", json_payload=req.to_dict()
+    )
+    assert response["status"] == "success"
+
+
+def test_split_order_item_payment(mock_api_request):
+    mock_api_request.return_value = {"status": "success"}
+
+    req = SplitOrderItemPaymentDTO(
+        order_id="order123", order_item_payment_id="pay123", amount=50.0
+    )
+    client = TapsilatAPI()
+    response = client.split_order_item_payment(req)
+
+    mock_api_request.assert_called_once_with(
+        "POST", "/order/split", json_payload=req.to_dict()
+    )
+    assert response["status"] == "success"
+
+
+def test_order_callback(mock_api_request):
+    mock_api_request.return_value = {"status": "success"}
+
+    client = TapsilatAPI()
+    response = client.order_callback("order123")
+
+    mock_api_request.assert_called_once_with("GET", "/orders/order123/callback")
+    assert response["status"] == "success"
+
+
+def test_order_vpos_query(mock_api_request):
+    mock_api_request.return_value = {"status": "success"}
+
+    client = TapsilatAPI()
+    response = client.order_vpos_query("order123")
+
+    mock_api_request.assert_called_once_with("GET", "/orders/order123/vpos-query")
+    assert response["status"] == "success"


### PR DESCRIPTION
- Added payment-options, split, callback, and vpos-query endpoints into the SDK.
- Added DTO models: OrderPaymentOptionsUpdateDTO and SplitOrderItemPaymentDTO.
- Implemented unit tests in `test_order.py` and integration scenarios in `integration_test.py`.